### PR TITLE
Use parameter store instead of embedding secrets in user data

### DIFF
--- a/groups/chips-uam-infrastructure/data.tf
+++ b/groups/chips-uam-infrastructure/data.tf
@@ -95,7 +95,7 @@ data "template_file" "chips_uam_userdata" {
     ANSIBLE_INPUTS       = jsonencode(local.chips_uam_ansible_inputs)
     HERITAGE_ENVIRONMENT = title(var.environment)
     API_KEY              = var.nagios_api_key
-    CHIPS_UAM_INPUTS     = local.chips_uam_data["master-txt"]
+    MASTER_DATA_PATH     = "/${var.application}/${var.environment}/master_data"
   }
 }
 

--- a/groups/chips-uam-infrastructure/iam.tf
+++ b/groups/chips-uam-infrastructure/iam.tf
@@ -19,7 +19,8 @@ module "chips_uam_profile" {
   ]) : null
   kms_key_refs = [
     "alias/${var.account}/${var.region}/ebs",
-    local.ssm_kms_key_id
+    local.ssm_kms_key_id,
+    local.account_ssm_key_arn
   ]
   s3_buckets_write = [local.session_manager_bucket_name]
   custom_statements = [
@@ -33,6 +34,14 @@ module "chips_uam_profile" {
       actions = [
         "s3:Get*",
         "s3:List*",
+      ]
+    },
+    {
+      sid       = "AllowReadOfParameterStore",
+      effect    = "Allow",
+      resources = ["arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/${var.application}/${var.environment}/*"],
+      actions = [
+        "ssm:GetParameter*"
       ]
     }
   ]

--- a/groups/chips-uam-infrastructure/locals.tf
+++ b/groups/chips-uam-infrastructure/locals.tf
@@ -13,6 +13,7 @@ locals {
   chips_uam_log_groups = compact([for log, map in local.chips_uam_logs : lookup(map, "log_group_name", "")])
 
   kms_keys_data          = data.vault_generic_secret.kms_keys.data
+  account_ssm_key_arn    = local.kms_keys_data["ssm"]
   security_kms_keys_data = data.vault_generic_secret.security_kms_keys.data
   ssm_kms_key_id         = local.security_kms_keys_data["session-manager-kms-key-arn"]
 
@@ -27,6 +28,10 @@ locals {
   chips_uam_ansible_inputs = {
     cw_log_files  = local.chips_uam_logs
     cw_agent_user = "root"
+  }
+
+  parameter_store_secrets = {
+    master_data = local.chips_uam_data["master-txt"]
   }
 
   default_tags = {

--- a/groups/chips-uam-infrastructure/parameter-store.tf
+++ b/groups/chips-uam-infrastructure/parameter-store.tf
@@ -1,0 +1,13 @@
+resource "aws_ssm_parameter" "parameters" {
+  for_each = local.parameter_store_secrets
+
+  name   = "/${var.application}/${var.environment}/${each.key}"
+  type   = "SecureString"
+  value  = each.value
+  key_id = local.account_ssm_key_arn
+
+  tags = {
+    Environment = var.environment
+    Application = var.application
+  }
+}

--- a/groups/chips-uam-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/chips-uam-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -14,7 +14,7 @@ environment = "development"
 
 # Instance detail
 ec2_name       = "chips-uam"
-ec2_size       = "m5.2xlarge"
+ec2_size       = "t3.large"
 retention_days = "true"
 
 #Cloudwatch log groups

--- a/groups/chips-uam-infrastructure/profiles/heritage-live-eu-west-2/vars
+++ b/groups/chips-uam-infrastructure/profiles/heritage-live-eu-west-2/vars
@@ -14,7 +14,7 @@ environment = "live"
 
 # Instance detail
 ec2_name       = "chips-uam"
-ec2_size       = "m5.2xlarge"
+ec2_size       = "t3.large"
 retention_days = "backup21"
 
 #Cloudwatch log groups

--- a/groups/chips-uam-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-uam-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -14,7 +14,7 @@ environment = "staging"
 
 # Instance detail
 ec2_name       = "chips-uam"
-ec2_size       = "m5.2xlarge"
+ec2_size       = "t3.large"
 retention_days = "backup14"
 
 #Cloudwatch log groups

--- a/groups/chips-uam-infrastructure/templates/chips_uam_user_data.tpl
+++ b/groups/chips-uam-infrastructure/templates/chips_uam_user_data.tpl
@@ -24,11 +24,8 @@ aws s3 cp s3://shared-services.eu-west-2.resources.ch.gov.uk/chips/uam/webswing-
 unzip /home/ec2-user/webswing-2.5.5-distribution.zip
 rm -rf /home/ec2-user/webswing-2.5.5-distribution.zip
 
-#Copy master.txt from vault to /home/ec2-user/uam
-#Create key:value variable
-cat <<EOF >> /home/ec2-user/uam/master.txt
-${CHIPS_UAM_INPUTS}
-EOF
+#Retrieve master.txt from parameter store
+aws ssm get-parameter --with-decryption --region ${REGION} --output text --query 'Parameter.Value' --name '${MASTER_DATA_PATH}' > /home/ec2-user/uam/master.txt
 
 chmod 700 /home/ec2-user/uam/master.txt
 


### PR DESCRIPTION
Avoid embedding any sensitive data in the user data script, and instead add the data to parameter store and then read it as the script runs.

Also reduces the instance sizes down to t3.large from m5.2xlarge.

Resolves:
https://companieshouse.atlassian.net/browse/DVOP-2674