### PR TITLE
Handle uam gui zip structure produced by build

### DIFF
--- a/groups/chips-uam-infrastructure/templates/chips_uam_user_data.tpl
+++ b/groups/chips-uam-infrastructure/templates/chips_uam_user_data.tpl
@@ -13,26 +13,22 @@ yum -y install java-1.8.0-openjdk
 yum -y install Xvfb
 
 #UAM GUI
-pushd /home/ec2-user/
-aws s3 cp s3://shared-services.eu-west-2.releases.ch.gov.uk/chips-user-admin-client/uam_gui-${UAM_GUI_VERSION}.zip /home/ec2-user/
-unzip /home/ec2-user/uam_gui-${UAM_GUI_VERSION}.zip
-rm -rf /home/ec2-user/uam_gui-${UAM_GUI_VERSION}.zip
-mv /home/ec2-user/uam_gui-${UAM_GUI_VERSION} /home/ec2-user/uam
+mkdir /home/ec2-user/uam
+pushd /home/ec2-user/uam
+aws s3 cp s3://shared-services.eu-west-2.releases.ch.gov.uk/chips-user-admin-client/uam_gui-${UAM_GUI_VERSION}.zip .
+unzip uam_gui-${UAM_GUI_VERSION}.zip
+rm -rf uam_gui-${UAM_GUI_VERSION}.zip
+
+#Retrieve master.txt from parameter store and encrypt
+aws ssm get-parameter --with-decryption --region ${REGION} --output text --query 'Parameter.Value' --name '${MASTER_DATA_PATH}' > master.txt
+./encryptUamDbConfigFile.sh master.txt
+rm -rf master.txt
 
 #Webswing
-aws s3 cp s3://shared-services.eu-west-2.resources.ch.gov.uk/chips/uam/webswing-2.5.5-distribution.zip /home/ec2-user/
-unzip /home/ec2-user/webswing-2.5.5-distribution.zip
-rm -rf /home/ec2-user/webswing-2.5.5-distribution.zip
-
-#Retrieve master.txt from parameter store
-aws ssm get-parameter --with-decryption --region ${REGION} --output text --query 'Parameter.Value' --name '${MASTER_DATA_PATH}' > /home/ec2-user/uam/master.txt
-
-chmod 700 /home/ec2-user/uam/master.txt
-
-#Encrypt master.txt
-pushd /home/ec2-user/uam/
-/home/ec2-user/uam/encryptUamDbConfigFile.sh master.txt
-rm -rf /home/ec2-user/uam/master.txt
+pushd /home/ec2-user
+aws s3 cp s3://shared-services.eu-west-2.resources.ch.gov.uk/chips/uam/webswing-2.5.5-distribution.zip .
+unzip webswing-2.5.5-distribution.zip
+rm -rf webswing-2.5.5-distribution.zip
 
 #Create a systemd script that will control the startup of webswing including automated restarts for reboots
 aws s3 cp s3://shared-services.eu-west-2.resources.ch.gov.uk/chips/uam/webswing.service /etc/systemd/system/


### PR DESCRIPTION
The UAM Tool code is being split out from the main CHIPS build and now has a separate git repo and pipeline which publishes the uam_gui zip package to the shared services releases bucket.

During testing, we have found that the terraform was expecting a top level folder within the zip package.  That folder was never present in the released packages, so this PR updates the terraform to work without the folder, and also tidies up the user data script slightly.

Partially resolves:
https://companieshouse.atlassian.net/browse/CHP-30